### PR TITLE
Report that this does not work in PyCharm.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,9 @@ There is an issue in Spyder where pressing and holding the backspace key yields 
 
 Currently I have only tested it in Windows 10, Manjaro and Parrot, so I'm not sure it works in macOS.  
 
-This will not work in Jupyter Notebook correctly. Haven't tested it in PyCharm yet, so it might work.
+This will not work in Jupyter Notebook correctly.
+
+This does not work in PyCharm, as reported by a PyCharm user.
 
 ### Tips
 


### PR DESCRIPTION
In Pycharm, when attempting to enter a password, the password shows just as in getpass. But worse yet, you can't even finish entering the password, it just continues to multiple lines indefinitely.